### PR TITLE
Squelch a 3.7+ Decprecation warning ...

### DIFF
--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -34,7 +34,12 @@ Documentation at <http://pqdict.readthedocs.org/en/latest>.
 :license: MIT, see LICENSE for more details.
 
 """
-from collections import MutableMapping as _MutableMapping
+try:
+    from collections.abc import MutableMapping as _MutableMapping
+except ImportError:
+    # 2.7 compatability
+    from collections import MutableMapping as _MutableMapping
+
 from six.moves import range
 from operator import lt, gt
 


### PR DESCRIPTION
which will be breakage in 3.9.

For compatability 2.7, is still supported.

Fixes #6