### PR TITLE
Refactor heap operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test clean build publish
+.PHONY: install test clean build publish docs
 
 install:
 	pip install -e .
@@ -17,6 +17,9 @@ clean:
 build: clean
 	python setup.py sdist
 	python setup.py bdist_wheel
+
+docs:
+	sphinx-autobuild docs docs/_build/html
 
 publish: 
 	twine upload dist/*

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -45,19 +45,21 @@ To create a max-heap instead (**larger** values give **higher** priority), pass 
     >>> list(pq.popkeys())
     ['c', 'b', 'a']
 
-Alternatively, you can use the alias functions ``minpq()`` and ``maxpq()``.
+Alternatively, you can use the constructors :meth:`~pqdict.pqdict.minpq` and :meth:`~pqdict.pqdict.maxpq`.
 
 .. code-block:: python
 
-    >>> from pqdict import minpq
-    >>> pq = minpq(a=3, b=5, c=8)
+    >>> from pqdict import pqdict
+    >>> pq = pqdict.minpq(a=3, b=5, c=8)
 
 By default, items are ordered by **value**. Analogous to the built-in ``sorted()``, you can provide a **priority key function** to transform the values for sorting.
 
 .. code-block:: python
     
     >>> from pqdict import pqdict
-    >>> pq = pqdict({'a':(2,3), 'b':(8,5), 'c':(10,8)}, key=lambda x: x[1])
+    >>> pq = pqdict({'a':(10, 3), 'b':(8, 5), 'c':(3, 8)}, key=lambda x: x[1])
+    >>> list(pq.popkeys())
+    ['a', 'b', 'c']
 
 Views and regular iteration don't affect the heap, but the output is **unsorted**. This applies to ``pq.keys()``, ``pq.values()``, ``pq.items()`` and using ``iter()`` (e.g., in a for loop).
 
@@ -69,11 +71,11 @@ Views and regular iteration don't affect the heap, but the output is **unsorted*
 
 .. code-block:: python 
 
-    >>> list(pqdict({'a': 1, 'b': 2, 'c': 3, 'd': 4}).keys())
+    >>> list(pqdict({'a': 1, 'c': 3, 'b': 2, 'd': 4}).keys())
     ['a', 'c', 'b', 'd']
 
 
-"Heapsort iterators" output data in **descending order** of priority by removing items from the collection. The following methods return heapsort iterators: ``pq.popkeys()``, ``pq.popvalues()``, and ``pq.popitems()``.
+"Heapsort iterators" output data in **descending order of priority** by removing items from the collection. The following methods return heapsort iterators: ``pq.popkeys()``, ``pq.popvalues()``, and ``pq.popitems()``.
 
 .. code-block:: python 
 
@@ -81,7 +83,13 @@ Views and regular iteration don't affect the heap, but the output is **unsorted*
         serve(customer) # Customer satisfaction guaranteed :) 
     # queue is now empty
 
-``pqdict`` supports all Python dictionary methods...
+.. code-block:: python 
+
+    >>> list(pqdict({'a': 1, 'c': 3, 'b': 2, 'd': 4}).popkeys())
+    ['a', 'b', 'c', 'd']
+
+
+:class:`~pqdict.pqdict` supports all Python dictionary methods...
 
 .. code-block:: python
 
@@ -108,6 +116,8 @@ Views and regular iteration don't affect the heap, but the output is **unsorted*
 
     >>> pq.top()
     'c'
+    >>> pq.topvalue()
+    1
     >>> pq.topitem()
     ('c', 1)
     # manual heapsort...
@@ -124,12 +134,12 @@ Views and regular iteration don't affect the heap, but the output is **unsorted*
 
 
 .. warning:: 
-    **Value mutability**. If you use mutable objects as values in a ``pqdict``, changes to the state of those objects can break the priority queue. If this does happen, the data structure can be repaired by calling ``pq.heapify()``. (But you probably shouldn't be using mutable values in the first place.)
+    **Value mutability**. If you use mutable objects as values in a :class:`~pqdict.pqdict`, changes to the state of those objects can break the priority queue. If this does happen, the data structure can be repaired by calling ``pq.heapify()``. (But you probably shouldn't be using mutable values in the first place.)
 
 .. note::
     **Custom precedence function**. The only difference between a min-pq and max-pq is that precedence of items is determined by comparing priority keys with the builtin ``<`` and ``>`` operators, respectively. If you would like to further customize the way items are prioritized, you can pass a boolean function ``precedes(pkey1, pkey2)`` to the initializer.
 
-The module functions ``nsmallest`` and ``nlargest`` work like the same functions in ``heapq`` but act on mappings instead of sequences, sorting by value:
+The module functions :func:`~pqdict.nsmallest` and :func:`~pqdict.nlargest` work like the same functions in :mod:`heapq` but act on mappings instead of sequences, sorting by value:
 
 .. code-block:: python
 
@@ -141,7 +151,7 @@ The module functions ``nsmallest`` and ``nlargest`` work like the same functions
 License 
 -------
 
-This module is released under the MIT license. The augmented heap implementation was adapted from the ``heapq`` module in the Python standard library, which was written by Kevin O'Connor and augmented by Tim Peters and Raymond Hettinger.
+This module is released under the MIT license. The augmented heap implementation was adapted from the :mod:`heapq` module in the Python standard library, which was written by Kevin O'Connor and augmented by Tim Peters and Raymond Hettinger.
 
 
 Documentation

--- a/docs/pqdict.rst
+++ b/docs/pqdict.rst
@@ -12,6 +12,8 @@ pqdict class
 .. autoclass:: pqdict
     :no-members:
 
+    .. automethod:: __init__
+
     .. automethod:: minpq
 
     .. automethod:: maxpq

--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -211,10 +211,10 @@ def heappushpop(
 
 
 class pqdict(MutableMapping):
-    """A mutable dict/priority queue mapping hashable keys to priority values.
+    """A mutable dict/priority queue that maps hashable keys to priority values.
 
     As a priority queue, items can be added and the top-priority item can be
-    viewed or dequeued. In addition, arbitrary items may be removed, retrieved,
+    viewed or dequeued. In addition, arbitrary items may be retrieved, removed,
     and have their priorities updated by key.
     """
 
@@ -250,10 +250,10 @@ class pqdict(MutableMapping):
 
         Notes
         -----
-        The default behavior is that of a min-priority queue, i.e. the item
-        with the *smallest* priority value is given *highest* priority. This
-        behavior can be reversed by specifying ``reverse=True`` or by providing
-        a custom precedence function via the ``precedes`` keyword argument.
+        The default behavior is that of a **min**-priority queue, i.e. the item
+        with the *smallest* value is given *highest* priority. This behavior
+        can be reversed by specifying ``reverse=True`` or by providing a custom
+        precedence function via the ``precedes`` keyword argument.
         Alternatively, use the explicit :meth:`pqdict.minpq` or
         :meth:`pqdict.maxpq` class methods.
         """
@@ -299,23 +299,23 @@ class pqdict(MutableMapping):
 
     @classmethod
     def minpq(cls: Type[Tpqdict], *args: Any, **kwargs: Any) -> Tpqdict:
-        """Create a pqdict with min-priority semantics: smallest is highest.
+        """Create a pqdict with min-priority semantics: smallest value is highest.
 
-        pqdict.minpq() -> new empty pqdict with min-priority semantics
-        pqdict.minpq(mapping) -> new minpq initialized from a mapping
-        pqdict.minpq(iterable) -> new minpq initialized from an iterable of pairs
-        pqdict.minpq(**kwargs) -> new minpq initialized with name=value pairs
+        * ``pqdict.minpq()`` -> new empty pqdict with min-priority semantics
+        * ``pqdict.minpq(mapping)`` -> new minpq initialized from a mapping
+        * ``pqdict.minpq(iterable)`` -> new minpq initialized from an iterable of pairs
+        * ``pqdict.minpq(**kwargs)`` -> new minpq initialized with name=value pairs
         """
         return cls(dict(*args, **kwargs), precedes=lt)
 
     @classmethod
     def maxpq(cls: Type[Tpqdict], *args: Any, **kwargs: Any) -> Tpqdict:
-        """Create a pqdict with max-priority semantics: largest is highest.
+        """Create a pqdict with max-priority semantics: largest value is highest.
 
-        pqdict.maxpq() -> new empty pqdict with max-priority semantics
-        pqdict.maxpq(mapping) -> new maxpq initialized from a mapping
-        pqdict.maxpq(iterable) -> new maxpq initialized from an iterable of pairs
-        pqdict.maxpq(**kwargs) -> new maxpq initialized with name=value pairs
+        * ``pqdict.maxpq()`` -> new empty pqdict with max-priority semantics
+        * ``pqdict.maxpq(mapping)`` -> new maxpq initialized from a mapping
+        * ``pqdict.maxpq(iterable)`` -> new maxpq initialized from an iterable of pairs
+        * ``pqdict.maxpq(**kwargs)`` -> new maxpq initialized with name=value pairs
         """
         return cls(dict(*args, **kwargs), precedes=gt)
 
@@ -377,7 +377,10 @@ class pqdict(MutableMapping):
             heappush(self._heap, self._position, self._precedes, node)
 
     def __delitem__(self, key: Any) -> None:
-        """Remove item. Raises a ``KeyError`` if key is not in the pqdict."""
+        """Remove item.
+
+        Raises a ``KeyError`` if key is not in the pqdict.
+        """
         if key not in self._position:
             raise KeyError(key)
         heappop(self._heap, self._position, self._precedes, self._position[key])
@@ -496,7 +499,10 @@ class pqdict(MutableMapping):
             return default
 
     def additem(self, key: Any, value: Any) -> None:
-        """Add a new item. Raises ``KeyError`` if key is already in the pqdict."""
+        """Add a new item.
+
+        Raises ``KeyError`` if key is already in the pqdict.
+        """
         if key in self._position:
             raise KeyError(f"{key} is already in the queue")
         prio = self._keyfn(value) if self._keyfn else value
@@ -615,7 +621,7 @@ def nlargest(n: int, mapping: Mapping, key: Optional[Callable[[Any], Any]] = Non
         The number of keys associated with the largest values
         in descending order
     mapping : Mapping
-        A mapping object
+        A dict-like object
     key : callable, optional
         Optional priority key function to transform values into priority keys
         for sorting. By default, the values are not transformed.
@@ -660,7 +666,7 @@ def nsmallest(n: int, mapping: Mapping, key: Optional[Callable[[Any], Any]] = No
         The number of keys associated with the smallest values
         in ascending order
     mapping : Mapping
-        A mapping object
+        A dict-like object
     key : callable, optional
         Optional priority key function to transform values into priority keys
         for sorting. By default, the values are not transformed.

--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -224,9 +224,9 @@ class pqdict(MutableMapping):
     def __init__(
         self,
         data: Optional[DictInputs] = None,
-        key: Optional[Callable[[Any], Any]] = None,
+        key: Optional[PrioKeyFn] = None,
         reverse: bool = False,
-        precedes: Callable[[Any, Any], bool] = lt,
+        precedes: PrecedesFn = lt,
     ) -> None:
         """Create a new priority queue dictionary.
 
@@ -283,12 +283,12 @@ class pqdict(MutableMapping):
             self.update(data)
 
     @property
-    def precedes(self) -> Callable[[Any, Any], bool]:
+    def precedes(self) -> PrecedesFn:
         """Priority key precedence function."""
         return self._precedes
 
     @property
-    def keyfn(self) -> Callable[[Any], Any]:
+    def keyfn(self) -> PrioKeyFn:
         """Priority key function."""
         return self._keyfn if self._keyfn is not None else lambda x: x
 
@@ -608,7 +608,7 @@ class pqdict(MutableMapping):
 #############
 
 
-def nlargest(n: int, mapping: Mapping, key: Optional[Callable[[Any], Any]] = None):
+def nlargest(n: int, mapping: Mapping, key: Optional[PrioKeyFn] = None):
     """Return the n keys associated with the largest values in a mapping.
 
     Takes a mapping and returns the n keys associated with the largest values
@@ -653,7 +653,7 @@ def nlargest(n: int, mapping: Mapping, key: Optional[Callable[[Any], Any]] = Non
     return out
 
 
-def nsmallest(n: int, mapping: Mapping, key: Optional[Callable[[Any], Any]] = None):
+def nsmallest(n: int, mapping: Mapping, key: Optional[PrioKeyFn] = None):
     """Return the n keys associated with the smallest values in a mapping.
 
     Takes a mapping and returns the n keys associated with the smallest values

--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -256,6 +256,7 @@ class pqdict(MutableMapping):
         precedence function via the ``precedes`` keyword argument.
         Alternatively, use the explicit :meth:`pqdict.minpq` or
         :meth:`pqdict.maxpq` class methods.
+
         """
         if reverse:
             if precedes == lt:
@@ -635,6 +636,7 @@ def nlargest(n: int, mapping: Mapping, key: Optional[PrioKeyFn] = None):
     This function is equivalent to:
 
     >>> [item[0] for item in heapq.nlargest(n, mapping.items(), lambda x: x[1])]
+
     """
     it = iter(mapping.items())
     pq = pqdict(key=key, precedes=lt)
@@ -680,6 +682,7 @@ def nsmallest(n: int, mapping: Mapping, key: Optional[PrioKeyFn] = None):
     This function is equivalent to:
 
     >>> [item[0] for item in heapq.nsmallest(n, mapping.items(), lambda x: x[1])]
+
     """
     it = iter(mapping.items())
     pq = pqdict(key=key, precedes=gt)

--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -50,7 +50,6 @@ from typing import (
     TypeVar,
     Union,
 )
-from warnings import warn
 
 __version__ = "1.3.0"
 __all__ = ["pqdict", "nlargest", "nsmallest"]
@@ -87,10 +86,7 @@ class Node(NamedTuple):
 
 
 def _sink(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    top: int = 0
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, top: int = 0
 ) -> None:
     # "Sink-to-the-bottom-then-swim" algorithm (Floyd, 1964)
     # Tends to reduce the number of comparisons when inserting "heavy"
@@ -127,7 +123,7 @@ def _swim(
     position: Dict[Any, int],
     precedes: PrecedesFn,
     pos: int,
-    top: int = 0
+    top: int = 0,
 ) -> None:
     # Grab the node from its place
     node = heap[pos]
@@ -146,11 +142,7 @@ def _swim(
     position[node.key] = pos
 
 
-def heapify(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn
-) -> None:
+def heapify(heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn) -> None:
     n = len(heap)
     # No need to look at any leaf nodes.
     for pos in reversed(range(n // 2)):
@@ -158,10 +150,7 @@ def heapify(
 
 
 def heaprepair(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    pos: int
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, pos: int
 ) -> None:
     # Repair the position of a modified node.
     # Bubble up or down depending on values of parent and children.
@@ -180,10 +169,7 @@ def heaprepair(
 
 
 def heappop(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    pos: int = 0
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, pos: int = 0
 ) -> Node:
     # Take the very last node and place it in the vacated spot. Let it
     # sink or swim until it reaches its new resting place.
@@ -198,10 +184,7 @@ def heappop(
 
 
 def heappush(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    node: Node
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, node: Node
 ) -> None:
     n = len(heap)
     heap.append(node)
@@ -210,10 +193,7 @@ def heappush(
 
 
 def heapupdate(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    node: Node
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, node: Node
 ) -> None:
     pos = position[node.key]
     heap[pos] = node
@@ -221,10 +201,7 @@ def heapupdate(
 
 
 def heappushpop(
-    heap: List[Node],
-    position: Dict[Any, int],
-    precedes: PrecedesFn,
-    node: Node
+    heap: List[Node], position: Dict[Any, int], precedes: PrecedesFn, node: Node
 ) -> Node:
     key = node.key
     if heap and precedes(heap[0].prio, node.prio):
@@ -456,7 +433,6 @@ class pqdict(MutableMapping):
         else:
             return default
 
-
     ######################
     # Priority Queue API #
     ######################
@@ -630,9 +606,7 @@ class pqdict(MutableMapping):
         else:
             if key not in self._position:
                 raise KeyError(key)
-            heaprepair(
-                self._heap, self._position, self._precedes, self._position[key]
-            )
+            heaprepair(self._heap, self._position, self._precedes, self._position[key])
 
 
 #############

--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -436,7 +436,7 @@ class pqdict(MutableMapping):
     def top(self, default: Any = __marker) -> Any:
         """Return the key of the item with highest priority.
 
-        If ``default`` is provided and pqdict is empty, then return``default``,
+        If ``default`` is provided and pqdict is empty, then return ``default``,
         otherwise raise ``Empty``.
         """
         if self._heap:
@@ -449,7 +449,7 @@ class pqdict(MutableMapping):
     def topvalue(self, default: Any = __marker) -> Any:
         """Return the value of the item with highest priority.
 
-        If ``default`` is provided and pqdict is empty, then return``default``,
+        If ``default`` is provided and pqdict is empty, then return ``default``,
         otherwise raise ``Empty``.
         """
         if self._heap:
@@ -475,7 +475,7 @@ class pqdict(MutableMapping):
     def popvalue(self, default: Any = __marker) -> Any:
         """Remove and return the value of the item with highest priority.
 
-        If ``default`` is provided and pqdict is empty, then return``default``,
+        If ``default`` is provided and pqdict is empty, then return ``default``,
         otherwise raise ``Empty``.
         """
         if self._heap:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,10 +70,10 @@ universal = true
 profile = "black"
 skip_gitignore = true
 
-[tool.ruff]
+[tool.ruff.lint]
 extend-select = [
     "E",  # style errors
-    # "D",  # pydocstyle
+    "D",  # pydocstyle
     "F",  # pyflakes
     "I",  # isort
     "RUF", # ruff-specific rules
@@ -81,6 +81,8 @@ extend-select = [
     "W",  # style  warnings
 ]
 ignore = [
+    "D100",
+    "D103",
     "D203",
     "D213",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ skip_gitignore = true
 [tool.ruff]
 extend-select = [
     "E",  # style errors
-    "D",  # pydocstyle
+    # "D",  # pydocstyle
     "F",  # pyflakes
     "I",  # isort
     "RUF", # ruff-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,14 @@ skip_gitignore = true
 [tool.ruff]
 extend-select = [
     "E",  # style errors
-    # "D",  # pydocstyle
+    "D",  # pydocstyle
     "F",  # pyflakes
     "I",  # isort
     "RUF", # ruff-specific rules
     "UP", # pyupgrade
     "W",  # style  warnings
+]
+ignore = [
+    "D203",
+    "D213",
 ]

--- a/tests/test_pqdict.py
+++ b/tests/test_pqdict.py
@@ -6,7 +6,7 @@ from itertools import combinations
 
 import pytest
 
-from pqdict import nlargest, nsmallest, pqdict, Empty
+from pqdict import Empty, nlargest, nsmallest, pqdict
 
 sample_keys = ["A", "B", "C", "D", "E", "F", "G"]
 sample_values = [5, 8, 7, 3, 9, 12, 1]

--- a/tests/test_pqdict.py
+++ b/tests/test_pqdict.py
@@ -6,7 +6,7 @@ from itertools import combinations
 
 import pytest
 
-from pqdict import maxpq, minpq, nlargest, nsmallest, pqdict
+from pqdict import nlargest, nsmallest, pqdict, Empty
 
 sample_keys = ["A", "B", "C", "D", "E", "F", "G"]
 sample_values = [5, 8, 7, 3, 9, 12, 1]
@@ -128,16 +128,6 @@ def test_fromkeys():
         assert pq[k] == float("-inf")
     pq["spam"] = 10
     assert pq.pop() == "spam"
-
-
-def test_factory_functions():
-    pq = minpq(A=5, B=8, C=7, D=3, E=9, F=12, G=1)
-    assert list(pq.popvalues()) == [1, 3, 5, 7, 8, 9, 12]
-    assert pq.precedes == operator.lt
-
-    pq = maxpq(A=5, B=8, C=7, D=3, E=9, F=12, G=1)
-    assert list(pq.popvalues()) == [12, 9, 8, 7, 5, 3, 1]
-    assert pq.precedes == operator.gt
 
 
 ################
@@ -300,7 +290,7 @@ def test_pop():
 
     # PQ-pop
     # no args and empty - throws
-    with pytest.raises(KeyError):
+    with pytest.raises(Empty):
         pq.pop()  # pq is now empty
     assert pq.pop(default="default") == "default"
     # no args - return top key
@@ -311,7 +301,7 @@ def test_pop():
 def test_top():
     # empty
     pq = pqdict()
-    with pytest.raises(KeyError):
+    with pytest.raises(Empty):
         pq.top()
     assert pq.top("default") == "default"
     # non-empty
@@ -332,7 +322,7 @@ def test_popitem():
 def test_topitem():
     # empty
     pq = pqdict()
-    with pytest.raises(KeyError):
+    with pytest.raises(Empty):
         pq.top()
     # non-empty
     for num_items in range(1, 30):


### PR DESCRIPTION
* Factor out heap operations to reduce redundancy
* Introduce an `Empty` exception for operations that attempt to pull from an empty pqdict, instead of raising a `KeyError`. We derive `Empty` from `KeyError` for subclass compatibility with `Mapping.popitem` and `Mapping.clear` which require a `KeyError`.
* Make internal heap nodes immutable and fast copy as in #14 
* Pydocstyle compliant docstrings
* Remove deprecated module `minpq` and `maxpq` in favor of classmethods.
* Refine type annotations

To-do:
- [x] Update Dijkstra example to use `pqdict.minpq` classmethod instead of module function.