### PR TITLE
fix: improve type inference for fromkeys and heapify

### DIFF
--- a/pqdict/__init__.py
+++ b/pqdict/__init__.py
@@ -371,8 +371,16 @@ class pqdict(MutableMapping[KT, VT]):
     # update = MutableMapping.update
     # setdefault = MutableMapping.setdefault
 
+    @overload
     @classmethod
-    def fromkeys(cls, iterable: Iterable[KT], value: VT, **kwargs: Any) -> Self:
+    def fromkeys(cls, iterable: Iterable[_K], value: _V, /) -> pqdict[_K, _V]: ...
+    @overload
+    @classmethod
+    def fromkeys(
+        cls, iterable: Iterable[_K], value: _V, **kwargs: Any
+    ) -> pqdict[_K, _V]: ...
+    @classmethod
+    def fromkeys(cls, iterable: Any, value: Any, **kwargs: Any) -> pqdict[Any, Any]:
         """Return a new pqdict mapping keys from an iterable to the same value."""
         return cls(((k, value) for k in iterable), **kwargs)
 
@@ -655,6 +663,10 @@ class pqdict(MutableMapping[KT, VT]):
         except Empty:
             return
 
+    @overload
+    def heapify(self) -> None: ...
+    @overload
+    def heapify(self, key: KT, /) -> None: ...
     def heapify(self, key: Any = __marker) -> None:
         """Repair a broken heap.
 

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -70,11 +70,17 @@ def test_module_function_types() -> None:
     assert_type(nsmallest(2, {1: "a"}), list[int])
 
 
-def test_fromkeys_typechecks() -> None:
-    # ``fromkeys`` parameterization is checker-dependent (mypy infers
-    # ``pqdict[str, int]``; pyright and ty fall back to ``pqdict[Any, Any]``),
-    # so we only assert that the call type-checks without error.
-    _ = pqdict.fromkeys(["a", "b"], 0)
+def test_fromkeys_inference() -> None:
+    # ``fromkeys`` uses method-local typevars in ``@overload`` stubs so that
+    # ``_K``/``_V`` are solved from the call arguments rather than the class
+    # generics (which a classmethod can't bind from its own args). Guards
+    # against regressing to the old ``Iterable[KT], VT -> Self`` shape, which
+    # collapsed to ``pqdict[Any, Any]`` at call sites under pyright/ty.
+    assert_type(pqdict.fromkeys(["a", "b"], 0), pqdict[str, int])
+    assert_type(
+        pqdict.fromkeys([1, 2], "x", precedes=lambda a, b: a < b),
+        pqdict[int, str],
+    )
 
 
 def test_unparameterized_defaults_to_any() -> None:


### PR DESCRIPTION
Fixes `pqdict.fromkeys([1, 2, 3], "x")` being inferred as `pqdict[Any, Any]`. 

Why? Class typevars `KT`/`VT` aren't bindable from a classmethod's own arguments, so the `Iterable[KT], VT -> Self` shape had nothing to solve against and fell back to PEP 696 defaults. Matching how we dealt with `minpq`/`maxpq`, we switch to method-local typevars in `@overload` stubs. This is the typeshed pattern used in stdlib `dict.fromkeys`.

Also tightens `heapify(key)` from `key: Any` to `key: KT` via overloads.
